### PR TITLE
Shortcircuit solved cubes

### DIFF
--- a/src/solve.c
+++ b/src/solve.c
@@ -98,6 +98,17 @@ solve_list_t *solve_single(const coord_cube_t *original_cube) {
 }
 
 solve_list_t *solve(const coord_cube_t *original_cube, const config_t *config) {
+    if (is_coord_solved(original_cube)) {
+        solve_list_t *solves       = new_solve_list_node();
+        solves->solution           = malloc(sizeof(move_t));
+        solves->solution[0]        = MOVE_NULL;
+        solves->phase1_solution    = malloc(sizeof(move_t));
+        solves->phase1_solution[0] = MOVE_NULL;
+        solves->phase2_solution    = malloc(sizeof(move_t));
+        solves->phase2_solution[0] = MOVE_NULL;
+        return solves;
+    }
+
     solve_list_t *solves = new_solve_list_node();
     coord_cube_t *cube   = get_coord_cube();
 

--- a/test/test_solve.c
+++ b/test/test_solve.c
@@ -434,6 +434,22 @@ void test_edge_case_solved_cube() {
     destroy_solve_list(solutions);
 }
 
+void test_solved_cube_returns_zero_length() {
+    coord_cube_t *cube = get_coord_cube();
+    reset_coord_cube(cube);
+
+    solve_list_t *solutions = solve_single(cube);
+    TEST_ASSERT_NOT_NULL(solutions);
+    TEST_ASSERT_NOT_NULL(solutions->solution);
+
+    int length = 0;
+    for (int i = 0; solutions->solution[i] != MOVE_NULL; i++) length++;
+    TEST_ASSERT_EQUAL(0, length);
+
+    free(cube);
+    destroy_solve_list(solutions);
+}
+
 void test_edge_case_single_move_scrambles() {
     coord_cube_t *cube = get_coord_cube();
 
@@ -526,6 +542,7 @@ int main() {
     RUN_TEST(test_solution_validity);
     RUN_TEST(test_phase2_solves_r2_l2_in_2_moves);
     RUN_TEST(test_edge_case_solved_cube);
+    RUN_TEST(test_solved_cube_returns_zero_length);
     RUN_TEST(test_edge_case_single_move_scrambles);
     RUN_TEST(test_solution_correctness_varied_depths);
     RUN_TEST(test_all_sample_facelets_produce_valid_solutions);


### PR DESCRIPTION
Return empty solution (length 0) for already-solved cubes instead of searching for a non-zero solution.