### PR TITLE
fix(solve): plug per-thread stats memory leak

### DIFF
--- a/src/solve.c
+++ b/src/solve.c
@@ -64,16 +64,13 @@ void destroy_solve_list_node(solve_list_t *node) {
         node->solution = NULL;
     }
 
+    free(node->stats);
+    node->stats = NULL;
+
     free(node);
 }
 
 void destroy_solve_list(solve_list_t *solves) {
-    if (solves == NULL)
-        return;
-
-    free(solves->stats);
-    solves->stats = NULL;
-
     while (solves != NULL) {
         solve_list_t *next = solves->next;
         destroy_solve_list_node(solves);
@@ -363,6 +360,10 @@ move_t *solve_phase1(solve_context_t *solve_context, solve_list_t *solves, solve
     // printf("solving phase1 with prep moves: ");
     // print_move_sequence(solve_context->prep_moves);
 
+    if (solves != NULL) {
+        solves->stats = stats;
+    }
+
     for (int allowed_depth = 1; allowed_depth <= config->max_depth; allowed_depth++) {
         int pivot = 0;
         /*printf("searching with max depth: %d\n", allowed_depth);*/
@@ -429,10 +430,6 @@ move_t *solve_phase1(solve_context_t *solve_context, solve_list_t *solves, solve
                 stats->phase1_depth      = pivot + 1;
                 stats->phase1_move_count = move_count;
                 stats->phase1_solve_time = (float)(end_time - phase2_time - start_time) / 1000000.0;
-
-                if (solves != NULL) {
-                    solves->stats = stats;
-                }
 
                 move_t *phase1_solution;
                 build_phase1_solution(move_stack, pivot, &solution, &phase1_solution);


### PR DESCRIPTION
## Problem
When multiple threads find solutions, each thread's head node has its own `stats` pointer. `destroy_solve_list` only freed the global head's stats, leaking stats from other threads.

Heap leak checker reported: `Leak of 80 bytes in 2 objects allocated from get_solve_stats → solve → solve_facelets → main`

## Root cause
PR #34 moved stats freeing from `destroy_solve_list_node` to `destroy_solve_list` (head-only) to fix a double-free. But this only handles the first thread's stats. Other threads' stats pointers (stored in their head nodes deeper in the list) are never freed.

## Fix
1. **Set stats once on thread head only**: move `solves->stats = stats` from inside the solution-found block (runs on every solution) to before the search loop (runs once per thread). Only the first node (head) gets stats; subsequent nodes created by `store_solution_in_list` keep `stats = NULL`.
2. **Revert `destroy_solve_list_node`**: free `node->stats` — safe because only head nodes have non-NULL stats; other nodes have NULL → `free(NULL)` is a no-op.
3. **Revert `destroy_solve_list`**: simple iteration, no special head-stats-free.

## After fix
- Thread 0's head: `free(stats)` → frees thread 0's stats ✓
- Thread 0's other nodes: `free(NULL)` → no-op ✓
- Thread 1's head: `free(stats)` → frees thread 1's stats ✓
- No double-free, no leak

## Test plan
- [x] All tests pass (47 tests across 7 suites)
- [x] Multi-solution still works
- [x] Custom heap checker CI should pass (was the only failure)