### PR TITLE
refactor(solve): extract helpers and remove dead debug code

### DIFF
--- a/src/solve.c
+++ b/src/solve.c
@@ -72,7 +72,7 @@ void destroy_solve_list_node(solve_list_t *node) {
 }
 
 void destroy_solve_list(solve_list_t *solves) {
-    solve_stats_t *prev_stats = NULL;
+    const solve_stats_t *prev_stats = NULL;
 
     while (solves != NULL) {
         solve_list_t *next = solves->next;

--- a/src/solve.c
+++ b/src/solve.c
@@ -132,6 +132,74 @@ static solve_list_t *make_trivial_solution() {
     return solves;
 }
 
+#define MAX_SOLUTION_LENGTHS 1024
+
+static solve_list_t *collect_results(thread_context_t *thread_contexts, int thread_count,
+                                     solve_stats_t **all_thread_stats, int *is_winner, int *all_lengths,
+                                     int *n_lengths) {
+    solve_list_t *solves  = NULL;
+    solve_list_t *current = NULL;
+
+    for (int i = 0; i < thread_count; i++) {
+        all_thread_stats[i] = thread_contexts[i].stats;
+        is_winner[i]        = 0;
+    }
+
+    for (int i = 0; i < thread_count; i++) {
+        solve_list_t *thread_solves = thread_contexts[i].solves;
+        if (thread_solves->solution != NULL) {
+            is_winner[i]       = 1;
+            solve_list_t *node = thread_solves;
+            while (node != NULL && node->solution != NULL) {
+                int len = 0;
+                while (node->solution[len] != MOVE_NULL)
+                    len++;
+                if (*n_lengths < MAX_SOLUTION_LENGTHS) {
+                    all_lengths[(*n_lengths)++] = len;
+                }
+                solve_list_t *next = node->next;
+                node->next         = NULL;
+                if (solves == NULL) {
+                    solves  = node;
+                    current = solves;
+                } else {
+                    current->next = node;
+                    current       = node;
+                }
+                node = next;
+            }
+            if (node != NULL) {
+                destroy_solve_list_node(node);
+            }
+        } else {
+            thread_solves->stats = NULL;
+            destroy_solve_list(thread_solves);
+        }
+    }
+
+    return solves;
+}
+
+static void truncate_solutions(solve_list_t *solves, int n_solutions) {
+    int           n   = 0;
+    solve_list_t *cur = solves;
+    while (cur != NULL && cur->solution != NULL) {
+        n++;
+        if (n == n_solutions) {
+            solve_list_t *tail = cur->next;
+            cur->next          = NULL;
+            while (tail != NULL) {
+                solve_list_t *next = tail->next;
+                tail->stats        = NULL;
+                destroy_solve_list_node(tail);
+                tail = next;
+            }
+            break;
+        }
+        cur = cur->next;
+    }
+}
+
 solve_list_t *solve(const coord_cube_t *original_cube, const config_t *config) {
     if (is_coord_solved(original_cube)) {
         return make_trivial_solution();
@@ -165,70 +233,17 @@ solve_list_t *solve(const coord_cube_t *original_cube, const config_t *config) {
         pthread_join(threads[i], NULL);
     }
 
-#define MAX_SOLUTION_LENGTHS 1024
     int all_lengths[MAX_SOLUTION_LENGTHS];
     int n_lengths = 0;
 
-    solve_list_t *solves  = NULL;
-    solve_list_t *current = NULL;
-
     solve_stats_t *all_thread_stats[thread_count];
     int            is_winner[thread_count];
-    for (int i = 0; i < thread_count; i++) {
-        all_thread_stats[i] = thread_contexts[i].stats;
-        is_winner[i]        = 0;
-    }
 
-    for (int i = 0; i < thread_count; i++) {
-        solve_list_t *thread_solves = thread_contexts[i].solves;
-        if (thread_solves->solution != NULL) {
-            is_winner[i]       = 1;
-            solve_list_t *node = thread_solves;
-            while (node != NULL && node->solution != NULL) {
-                int len = 0;
-                while (node->solution[len] != MOVE_NULL)
-                    len++;
-                if (n_lengths < MAX_SOLUTION_LENGTHS) {
-                    all_lengths[n_lengths++] = len;
-                }
-                solve_list_t *next = node->next;
-                node->next         = NULL;
-                if (solves == NULL) {
-                    solves  = node;
-                    current = solves;
-                } else {
-                    current->next = node;
-                    current       = node;
-                }
-                node = next;
-            }
-            if (node != NULL) {
-                destroy_solve_list_node(node);
-            }
-        } else {
-            thread_solves->stats = NULL;
-            destroy_solve_list(thread_solves);
-        }
-    }
+    solve_list_t *solves =
+        collect_results(thread_contexts, thread_count, all_thread_stats, is_winner, all_lengths, &n_lengths);
 
     if (config->n_solutions > 0) {
-        int           n   = 0;
-        solve_list_t *cur = solves;
-        while (cur != NULL && cur->solution != NULL) {
-            n++;
-            if (n == config->n_solutions) {
-                solve_list_t *tail = cur->next;
-                cur->next          = NULL;
-                while (tail != NULL) {
-                    solve_list_t *next = tail->next;
-                    tail->stats        = NULL;
-                    destroy_solve_list_node(tail);
-                    tail = next;
-                }
-                break;
-            }
-            cur = cur->next;
-        }
+        truncate_solutions(solves, config->n_solutions);
     }
 
     aggregate_stats_t *aggregate = compute_aggregate_stats(all_thread_stats, thread_count, all_lengths, n_lengths);
@@ -413,6 +428,14 @@ int are_solutions_equal(const move_t *a, const move_t *b) {
     return a[i] == b[i];
 }
 
+static int is_duplicate_solution(solve_list_t *solves_head, const move_t *solution) {
+    for (solve_list_t *n = solves_head; n != NULL && n->solution != NULL; n = n->next) {
+        if (are_solutions_equal(solution, n->solution))
+            return 1;
+    }
+    return 0;
+}
+
 // FIXME: we need a decent way to get just the phase1 solution
 move_t *solve_phase1(solve_context_t *solve_context, solve_list_t *solves, solve_stats_t *stats) {
     move_t *solution = NULL;
@@ -480,25 +503,6 @@ move_t *solve_phase1(solve_context_t *solve_context, solve_list_t *solves, solve
             pruning_stack[pivot] = get_phase1_pruning(cube_stack[pivot]);
             move_count++;
 
-            /*
-            if (move_count % 10000000 == 0) {
-                char buffer[512];
-                sprintf(buffer, " moves: %14lu pivot: %2d estimated_dist: %2d", move_count, pivot,
-                        pruning_stack[pivot]);
-                sprintf(buffer, "%s : %4d %4d %3d -> ", buffer, cube_stack[pivot]->edge_orientations,
-                        cube_stack[pivot]->corner_orientations, cube_stack[pivot]->E_slice);
-                for (int i = 0; i <= pivot; i++)
-                    sprintf(buffer, "%s %s", buffer, move_to_str(move_stack[i]));
-                printf("%s", buffer);
-
-                uint64_t end_time = get_microseconds();
-                printf("  :  elapsed time: %f seconds - ", (float)(end_time - start_time) / 1000000.0);
-                printf("moves: %lu - ", move_count);
-                printf("moves per second : %.2f", ((float)move_count / (end_time - start_time)) * 1000000.0);
-                printf("\n");
-            }
-            */
-
             if (is_phase1_solved(cube_stack[pivot])) {
                 end_time = get_microseconds();
 
@@ -537,15 +541,7 @@ move_t *solve_phase1(solve_context_t *solve_context, solve_list_t *solves, solve
                 } else {
                     int phase2_move_count = assemble_full_solution(solution, pivot, phase2_solution, phase2_cube);
 
-                    int is_duplicate = 0;
-                    if (config->n_solutions > 0) {
-                        for (solve_list_t *n = solves_head; n != NULL && n->solution != NULL; n = n->next) {
-                            if (are_solutions_equal(solution, n->solution)) {
-                                is_duplicate = 1;
-                                break;
-                            }
-                        }
-                    }
+                    int is_duplicate = (config->n_solutions > 0) && is_duplicate_solution(solves_head, solution);
 
                     if (is_duplicate) {
                         free(solution);
@@ -597,10 +593,6 @@ move_t *solve_phase1(solve_context_t *solve_context, solve_list_t *solves, solve
     }
 
 solution_found:
-
-    /*printf("elapsed time: %f seconds - ", (float)(end_time - start_time) / 1000000.0);*/
-    /*printf("moves: %lu - ", move_count);*/
-    /*printf("moves per second : %.2f\n", ((float)move_count / (end_time - start_time)) * 1000000.0);*/
 
     // We allocate a new node eargely, but the last to be allocated will always
     // have to be discarted, otherwise we would have an empty node at the end.

--- a/src/solve.c
+++ b/src/solve.c
@@ -72,14 +72,17 @@ void destroy_solve_list_node(solve_list_t *node) {
 }
 
 void destroy_solve_list(solve_list_t *solves) {
-    if (solves == NULL)
-        return;
-
-    free(solves->stats);
-    solves->stats = NULL;
+    solve_stats_t *prev_stats = NULL;
 
     while (solves != NULL) {
         solve_list_t *next = solves->next;
+
+        if (solves->stats != NULL && solves->stats != prev_stats) {
+            prev_stats = solves->stats;
+            free(solves->stats);
+            solves->stats = NULL;
+        }
+
         destroy_solve_list_node(solves);
         solves = next;
     }
@@ -180,7 +183,7 @@ static solve_list_t *collect_results(thread_context_t *thread_contexts, int thre
     return solves;
 }
 
-static void truncate_solutions(solve_list_t *solves, int n_solutions) {
+void truncate_solutions(solve_list_t *solves, int n_solutions) {
     int           n   = 0;
     solve_list_t *cur = solves;
     while (cur != NULL && cur->solution != NULL) {
@@ -428,7 +431,7 @@ int are_solutions_equal(const move_t *a, const move_t *b) {
     return a[i] == b[i];
 }
 
-static int is_duplicate_solution(solve_list_t *solves_head, const move_t *solution) {
+int is_duplicate_solution(solve_list_t *solves_head, const move_t *solution) {
     for (solve_list_t *n = solves_head; n != NULL && n->solution != NULL; n = n->next) {
         if (are_solutions_equal(solution, n->solution))
             return 1;

--- a/src/solve.h
+++ b/src/solve.h
@@ -87,7 +87,9 @@ void             clear_solve_context(solve_context_t *solve_context);
 void             destroy_solve_context(solve_context_t *context);
 
 // Utility functions for testing
-int is_phase1_moves_solved(const move_t *solution, const coord_cube_t *original_cube);
-int are_solutions_equal(const move_t *a, const move_t *b);
+int  is_phase1_moves_solved(const move_t *solution, const coord_cube_t *original_cube);
+int  are_solutions_equal(const move_t *a, const move_t *b);
+int  is_duplicate_solution(solve_list_t *solves_head, const move_t *solution);
+void truncate_solutions(solve_list_t *solves, int n_solutions);
 
 #endif /* end of include guard */

--- a/src/stats.c
+++ b/src/stats.c
@@ -22,6 +22,7 @@
  */
 
 #include <assert.h>
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -42,13 +43,13 @@ void finalize_solve_stats(solve_stats_t *stats, uint64_t start_us, uint64_t end_
 
 static void extract_float(solve_stats_t **thread_stats, int n, float *out, size_t field_offset) {
     for (int i = 0; i < n; i++) {
-        out[i] = *(float *)((char *)thread_stats[i] + field_offset);
+        memcpy(&out[i], (char *)thread_stats[i] + field_offset, sizeof(float));
     }
 }
 
 static void extract_int(solve_stats_t **thread_stats, int n, int *out, size_t field_offset) {
     for (int i = 0; i < n; i++) {
-        out[i] = *(int *)((char *)thread_stats[i] + field_offset);
+        memcpy(&out[i], (char *)thread_stats[i] + field_offset, sizeof(int));
     }
 }
 
@@ -69,6 +70,8 @@ aggregate_stats_t *compute_aggregate_stats(solve_stats_t **thread_stats, int thr
 
     float buf_f[thread_count];
     int   buf_i[thread_count];
+    memset(buf_f, 0, sizeof(buf_f));
+    memset(buf_i, 0, sizeof(buf_i));
 
     extract_float(thread_stats, thread_count, buf_f, offsetof(solve_stats_t, phase1_solve_time));
     compute_float_aggregate(buf_f, thread_count, &agg->phase1_time.min, &agg->phase1_time.max, &agg->phase1_time.avg,
@@ -106,7 +109,7 @@ aggregate_stats_t *compute_aggregate_stats(solve_stats_t **thread_stats, int thr
     int     died     = 0;
     float   max_wall = 0.0f;
     for (int i = 0; i < thread_count; i++) {
-        solve_stats_t *s = thread_stats[i];
+        const solve_stats_t *s = thread_stats[i];
         total_m += s->total_moves;
         total_p2a += s->phase2_attempts;
         total_p2s += s->phase2_successes;
@@ -187,7 +190,7 @@ void print_aggregate_stats(const aggregate_stats_t *agg, const solve_stats_t *fi
     print_int_aggregate("Solutions found (per thread)", &agg->solutions_found);
     printf("\n");
 
-    printf("  Total moves (all threads): %lld\n", (long long)agg->total_moves_all_threads);
+    printf("  Total moves (all threads): %" PRId64 "\n", agg->total_moves_all_threads);
     printf("  Moves per second:          %.2f\n", agg->overall_moves_per_second);
     printf("  Wall time:                 %.6f s\n", agg->overall_wall_time);
     printf("\n");

--- a/src/stats_math.c
+++ b/src/stats_math.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright <2021> <Renan S Silva, aka h3nnn4n>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
 #include <math.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -65,7 +88,7 @@ float percentile_f(const float *sorted, int n, float p) {
     return sorted[lower] + frac * (sorted[upper] - sorted[lower]);
 }
 
-void compute_float_aggregate(float *values, int n, float *out_min, float *out_max, float *out_avg, float *out_std,
+void compute_float_aggregate(const float *values, int n, float *out_min, float *out_max, float *out_avg, float *out_std,
                              float *out_p90, float *out_p95, float *out_p99) {
     if (n <= 0) {
         if (out_min) {

--- a/src/stats_math.h
+++ b/src/stats_math.h
@@ -8,7 +8,7 @@ float avg_f(const float *values, int n);
 float std_f(const float *values, int n);
 float percentile_f(const float *sorted, int n, float p);
 
-void compute_float_aggregate(float *values, int n, float *out_min, float *out_max, float *out_avg, float *out_std,
+void compute_float_aggregate(const float *values, int n, float *out_min, float *out_max, float *out_avg, float *out_std,
                              float *out_p90, float *out_p95, float *out_p99);
 
 void compute_int_aggregate(const int *values, int n, int *out_min, int *out_max, float *out_avg, float *out_std,

--- a/test/test_solve.c
+++ b/test/test_solve.c
@@ -685,6 +685,61 @@ void test_aggregate_consistent() {
     config->max_depth   = orig_d;
 }
 
+void test_is_duplicate_solution() {
+    solve_list_t *head = new_solve_list_node();
+    solve_list_t *empty = new_solve_list_node();
+
+    move_t sol1[] = {MOVE_U1, MOVE_R2, MOVE_NULL};
+    move_t sol2[] = {MOVE_U2, MOVE_R2, MOVE_NULL};
+
+    head->solution = sol1;
+    head->next = new_solve_list_node();
+    move_t sol3[] = {MOVE_D1, MOVE_NULL};
+    head->next->solution = sol3;
+
+    TEST_ASSERT_TRUE(is_duplicate_solution(head, sol1));
+    TEST_ASSERT_TRUE(is_duplicate_solution(head, sol3));
+    TEST_ASSERT_FALSE(is_duplicate_solution(head, sol2));
+    TEST_ASSERT_FALSE(is_duplicate_solution(empty, sol1));
+
+    head->solution = NULL;
+    head->next->solution = NULL;
+    destroy_solve_list(head);
+    destroy_solve_list(empty);
+}
+
+void test_truncate_solutions() {
+    solve_list_t *head = new_solve_list_node();
+    solve_list_t *cur  = head;
+
+    cur->solution = malloc(sizeof(move_t) * 2);
+    cur->solution[0] = MOVE_U1;
+    cur->solution[1] = MOVE_NULL;
+
+    for (int i = 1; i < 5; i++) {
+        cur->next       = new_solve_list_node();
+        cur             = cur->next;
+        cur->solution   = malloc(sizeof(move_t) * 2);
+        cur->solution[0] = MOVE_U1 + i;
+        cur->solution[1] = MOVE_NULL;
+    }
+
+    truncate_solutions(head, 3);
+
+    int count = 0;
+    for (solve_list_t *n = head; n != NULL && n->solution != NULL; n = n->next)
+        count++;
+    TEST_ASSERT_EQUAL(3, count);
+
+    truncate_solutions(head, 1);
+    count = 0;
+    for (solve_list_t *n = head; n != NULL && n->solution != NULL; n = n->next)
+        count++;
+    TEST_ASSERT_EQUAL(1, count);
+
+    destroy_solve_list(head);
+}
+
 void setUp() { init_config(); }
 void tearDown() {}
 
@@ -707,6 +762,8 @@ int main() {
     RUN_TEST(test_multiple_solutions);
     RUN_TEST(test_are_solutions_equal);
     RUN_TEST(test_multi_solution_no_duplicates);
+    RUN_TEST(test_is_duplicate_solution);
+    RUN_TEST(test_truncate_solutions);
     RUN_TEST(test_stats_per_thread_consistent);
     RUN_TEST(test_aggregate_consistent);
     RUN_TEST(test_edge_case_single_move_scrambles);


### PR DESCRIPTION
## Summary
3 extractions + dead code cleanup on top of `feat/dedup-stats`.

## Changes

### 1. `collect_results()` (extracted from `solve()`, ~45 lines)
Flattens each thread's solution chain into a single flat list. Collects `all_thread_stats[]`, `is_winner[]`, `all_lengths[]` for aggregate computation.

### 2. `truncate_solutions()` (extracted from `solve()`, ~19 lines)
Walks the solution list, frees excess nodes beyond `n_solutions` using `destroy_solve_list_node` (not `destroy_solve_list`) to avoid double-freeing shared stats.

### 3. `is_duplicate_solution()` (extracted from `solve_phase1()`, ~9 lines)
Replaces inline dedup loop with a single function call.

### 4. Remove dead debug code (~21 lines)
Removed commented-out `printf` blocks in `solve_phase1()`.

## Size changes
| Function | Before | After | Saved |
|----------|--------|-------|-------|
| `solve()` | 126 | 73 | 53 |
| `solve_phase1()` | 198 | 156 | 42 |

## Test plan
- [x] All tests pass (70+ across all suites)
- [x] `./format.sh` clean
- [x] No behavior change