### PR TITLE
refactor(stats): remove dead init_stats and dump_stats

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -151,8 +151,6 @@ int main(int argc, char **argv) {
 
     build_move_tables();
     build_pruning_tables();
-    init_stats();
-
     if (config->do_benchmark_fast) {
         run_benchmark_fast();
     } else if (config->do_benchmark_slow) {
@@ -200,8 +198,6 @@ int main(int argc, char **argv) {
     }
 
     purge_cubie_move_table();
-
-    dump_stats();
 
     return 0;
 }

--- a/src/stats.c
+++ b/src/stats.c
@@ -228,6 +228,3 @@ solve_stats_t *get_solve_stats() {
     memset(stats, 0, sizeof(solve_stats_t));
     return stats;
 }
-
-void init_stats() {}
-void dump_stats() {}

--- a/src/stats.h
+++ b/src/stats.h
@@ -89,8 +89,6 @@ aggregate_stats_t *compute_aggregate_stats(solve_stats_t **thread_stats, int thr
 
 void print_aggregate_stats(const aggregate_stats_t *agg, const solve_stats_t *first_solution);
 
-void           init_stats();
-void           dump_stats();
 void           print_solve_stats(const solve_stats_t *stats);
 solve_stats_t *get_solve_stats();
 


### PR DESCRIPTION
Remove no-op `init_stats()` and `dump_stats()` functions left over from stats redesign (PR #35).