### PR TITLE
refactor(solve): replace n_solutions==0 magic value with phase1_only flag

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -34,6 +34,7 @@ void init_config() {
     config.rebuild_tables    = 0;
     config.max_depth         = 25;
     config.n_solutions       = 1;
+    config.phase1_only       = false;
     config.timeout           = 1;
     config.scramble_moves    = NULL;
 

--- a/src/config.h
+++ b/src/config.h
@@ -31,12 +31,13 @@
 #include "definitions.h"
 
 typedef struct {
-    int do_benchmark_fast;
-    int do_benchmark_slow;
-    int do_solve;
-    int rebuild_tables;
-    int max_depth;
-    int n_solutions;
+    int  do_benchmark_fast;
+    int  do_benchmark_slow;
+    int  do_solve;
+    int  rebuild_tables;
+    int  max_depth;
+    int  n_solutions;
+    bool phase1_only;
 
     float timeout;
 

--- a/src/main.c
+++ b/src/main.c
@@ -53,6 +53,7 @@ int main(int argc, char **argv) {
                                     {"max-depth", required_argument, 0, 'm'},
                                     {"n-solutions", required_argument, 0, 'n'},
                                     {"move-blacklist", required_argument, 0, 'b'},
+                                    {"phase1-only", no_argument, 0, '1'},
                                     {0, 0, 0, 0}};
 
     while (1) {
@@ -136,12 +137,21 @@ int main(int argc, char **argv) {
                 config->scramble_moves = move_sequence_str_to_moves(optarg);
             } break;
 
+            case '1':
+                config->phase1_only = true;
+                config->n_solutions = 0;
+                break;
+
             case '?':
                 /* getopt_long already printed an error message. */
                 break;
 
             default: abort();
         }
+    }
+
+    if (config->n_solutions == 0) {
+        config->phase1_only = true;
     }
 
     if (config->rebuild_tables) {

--- a/src/solve.c
+++ b/src/solve.c
@@ -297,7 +297,9 @@ solve_list_t *solve_thread(void *arg) {
         }
 
         assert(is_phase1_solved(cube));
-        assert(is_phase2_solved(cube));
+        if (!get_config()->phase1_only) {
+            assert(is_phase2_solved(cube));
+        }
 
         free(cube);
     }
@@ -439,7 +441,6 @@ int is_duplicate_solution(solve_list_t *solves_head, const move_t *solution) {
     return 0;
 }
 
-// FIXME: we need a decent way to get just the phase1 solution
 move_t *solve_phase1(solve_context_t *solve_context, solve_list_t *solves, solve_stats_t *stats) {
     move_t *solution = NULL;
 
@@ -520,7 +521,11 @@ move_t *solve_phase1(solve_context_t *solve_context, solve_list_t *solves, solve
                 move_t *phase1_solution;
                 build_phase1_solution(move_stack, pivot, &solution, &phase1_solution);
 
-                if (config->n_solutions == 0) {
+                if (config->phase1_only) {
+                    if (solves != NULL) {
+                        solves->solution        = solution;
+                        solves->phase1_solution = phase1_solution;
+                    }
                     get_config()->die = true;
                     goto solution_found;
                 }


### PR DESCRIPTION
Replace unintuitive `n_solutions == 0` magic value ("find 0 solutions") with a clear `phase1_only` bool field.

Changes:
- `src/config.h`: add `bool phase1_only` field to `config_t`
- `src/config.c`: initialize `config.phase1_only = false`
- `src/solve.c`: replace `config->n_solutions == 0` with `config->phase1_only`, store solution in solves list before goto, conditionally skip phase2 assertion. Remove FIXME comment.
- `src/main.c`: add `--phase1-only` CLI flag. Keep backward compat (`n_solutions == 0` sets `phase1_only = true`).

Also fixes a pre-existing bug: the `n_solutions == 0` path allocated the solution but never stored it in the solves list, so `solve_thread` would see `solves->solution == NULL` and discard the result. Now the solution is properly stored before jumping to `solution_found`, and the phase2 assertion in `solve_thread` is skipped when `phase1_only` is set.