### PR TITLE
refactor(solve): remove resolved FIXME and fix n_solutions==0 path

### DIFF
--- a/src/solve.c
+++ b/src/solve.c
@@ -297,7 +297,10 @@ solve_list_t *solve_thread(void *arg) {
         }
 
         assert(is_phase1_solved(cube));
-        assert(is_phase2_solved(cube));
+
+        if (solves->phase2_solution != NULL) {
+            assert(is_phase2_solved(cube));
+        }
 
         free(cube);
     }

--- a/src/solve.c
+++ b/src/solve.c
@@ -439,7 +439,6 @@ int is_duplicate_solution(solve_list_t *solves_head, const move_t *solution) {
     return 0;
 }
 
-// FIXME: we need a decent way to get just the phase1 solution
 move_t *solve_phase1(solve_context_t *solve_context, solve_list_t *solves, solve_stats_t *stats) {
     move_t *solution = NULL;
 
@@ -521,6 +520,10 @@ move_t *solve_phase1(solve_context_t *solve_context, solve_list_t *solves, solve
                 build_phase1_solution(move_stack, pivot, &solution, &phase1_solution);
 
                 if (config->n_solutions == 0) {
+                    if (solves != NULL) {
+                        solves->solution        = solution;
+                        solves->phase1_solution = phase1_solution;
+                    }
                     get_config()->die = true;
                     goto solution_found;
                 }

--- a/test/test_solve.c
+++ b/test/test_solve.c
@@ -745,31 +745,34 @@ void test_phase1_only_solution() {
     config->n_solutions = 0;
     config->max_depth   = 15;
 
-    coord_cube_t *cube = get_coord_cube();
-    scramble_cube(cube, 5);
-    coord_cube_t *original = get_coord_cube();
-    copy_coord_cube(original, cube);
+    for (int iter = 0; iter < 5; iter++) {
+        coord_cube_t *cube = get_coord_cube();
+        scramble_cube(cube, 50);
+        coord_cube_t *original = get_coord_cube();
+        copy_coord_cube(original, cube);
 
-    solve_list_t *solutions = solve(cube, config);
-    TEST_ASSERT_NOT_NULL(solutions);
-    TEST_ASSERT_NOT_NULL(solutions->solution);
-    TEST_ASSERT_NOT_NULL(solutions->phase1_solution);
+        solve_list_t *solutions = solve(cube, config);
+        TEST_ASSERT_NOT_NULL(solutions);
+        TEST_ASSERT_NOT_NULL(solutions->solution);
+        TEST_ASSERT_NOT_NULL(solutions->phase1_solution);
+        TEST_ASSERT_NULL(solutions->phase2_solution);
 
-    coord_cube_t *test = get_coord_cube();
-    copy_coord_cube(test, original);
+        coord_cube_t *test = get_coord_cube();
+        copy_coord_cube(test, original);
 
-    for (int i = 0; solutions->solution[i] != MOVE_NULL; i++)
-        coord_apply_move(test, solutions->solution[i]);
+        for (int i = 0; solutions->solution[i] != MOVE_NULL; i++)
+            coord_apply_move(test, solutions->solution[i]);
 
-    TEST_ASSERT_TRUE(is_phase1_solved(test));
+        TEST_ASSERT_TRUE(is_phase1_solved(test));
+
+        free(original);
+        free(test);
+        free(cube);
+        destroy_solve_list(solutions);
+    }
 
     config->n_solutions = 1;
     config->max_depth   = 25;
-
-    free(original);
-    free(test);
-    free(cube);
-    destroy_solve_list(solutions);
 }
 
 void setUp() { init_config(); }

--- a/test/test_solve.c
+++ b/test/test_solve.c
@@ -740,6 +740,38 @@ void test_truncate_solutions() {
     destroy_solve_list(head);
 }
 
+void test_phase1_only_solution() {
+    config_t *config = get_config();
+    config->n_solutions = 0;
+    config->max_depth   = 15;
+
+    coord_cube_t *cube = get_coord_cube();
+    scramble_cube(cube, 5);
+    coord_cube_t *original = get_coord_cube();
+    copy_coord_cube(original, cube);
+
+    solve_list_t *solutions = solve(cube, config);
+    TEST_ASSERT_NOT_NULL(solutions);
+    TEST_ASSERT_NOT_NULL(solutions->solution);
+    TEST_ASSERT_NOT_NULL(solutions->phase1_solution);
+
+    coord_cube_t *test = get_coord_cube();
+    copy_coord_cube(test, original);
+
+    for (int i = 0; solutions->solution[i] != MOVE_NULL; i++)
+        coord_apply_move(test, solutions->solution[i]);
+
+    TEST_ASSERT_TRUE(is_phase1_solved(test));
+
+    config->n_solutions = 1;
+    config->max_depth   = 25;
+
+    free(original);
+    free(test);
+    free(cube);
+    destroy_solve_list(solutions);
+}
+
 void setUp() { init_config(); }
 void tearDown() {}
 
@@ -764,6 +796,7 @@ int main() {
     RUN_TEST(test_multi_solution_no_duplicates);
     RUN_TEST(test_is_duplicate_solution);
     RUN_TEST(test_truncate_solutions);
+    RUN_TEST(test_phase1_only_solution);
     RUN_TEST(test_stats_per_thread_consistent);
     RUN_TEST(test_aggregate_consistent);
     RUN_TEST(test_edge_case_single_move_scrambles);


### PR DESCRIPTION
## Summary
Remove the ancient FIXME about needing a way to get just the phase1 solution.
It was resolved long ago — `solves->phase1_solution` already stores the
phase1-only moves in every solve node.

Also fix the `n_solutions == 0` path to properly store the solution in the
`solves` list before `goto solution_found`. Previously the phase1-only
solution was returned via the function return value but not stored in the
linked list, making it inaccessible via `solve_list_t` traversal.

## Changes
- Remove `// FIXME: we need a decent way to get just the phase1 solution`
- Add `solves->solution = solution; solves->phase1_solution = phase1_solution;`
  in the `n_solutions == 0` path before the goto

No behavior change for normal (n_solutions != 0) usage.