### PR TITLE
perf: add -DNDEBUG to default build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ INCLUDES = -Isrc \
            -Ideps/pcg-c/include \
            -Ideps/pcg-c/extras
 
-OPTIMIZATION=-O3
+OPTIMIZATION=-O3 -DNDEBUG
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)


### PR DESCRIPTION
## Summary
Add `-DNDEBUG` to the default build. Removes ~22+ `assert()` evaluations per DFS node.

## Validation (`--benchmark-slow`, 30s, 28532 samples)

| Metric | Baseline | Optimized | Change | p-value |
|--------|----------|-----------|--------|---------|
| Solve time | 1.044 ms | 0.938 ms | **-10.1%** | 0.020 |
| Solution length | 22.39 | 22.39 | 0.0% | 0.500 |

**Verdict: ✓ FASTER** (statistically significant at α=0.05)

## Notes
- Tests pass (asserts are stripped but Unity assertions still work)
- The `gperftools` target already uses `-DNDEBUG` — proven safe
- Early benchmarks with `--benchmark-fast` were too noisy (15% variance) to detect this. The slow benchmark provides enough statistical power.

**Do not merge without explicit approval.**