### PR TITLE
build: add release and release-native targets

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -17,8 +17,8 @@ jobs:
           fetch-depth: 1
           submodules: true
 
-      - name: Build
-        run: make
+      - name: Build (release mode)
+        run: make release
 
       - name: Cache Tables
         id: cache-tables

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,8 @@ OBJS_NO_MAIN := $(filter-out %main.o, $(OBJS)) \
 .PHONY: heapcheck-solve
 .PHONY: heapcheck-solve-blacklist
 .PHONY: heapcheck-benchmark
+.PHONY: release
+.PHONY: release-native
 .PHONY: ci
 
 all: build
@@ -76,6 +78,16 @@ callgrind: callgrind_prepare build
 
 callgrind_prepare:
 	$(eval OPTIMIZATION=-g -O2 -DNDEBUG -fno-inline-functions -fno-inline-functions-called-once -fno-optimize-sibling-calls -fno-default-inline -fno-inline)
+
+release: clean release_prepare build
+release_prepare:
+	$(eval OPTIMIZATION=-O3 -DNDEBUG -flto)
+	$(eval override LDFLAGS += -flto)
+
+release-native: clean release_native_prepare build
+release_native_prepare:
+	$(eval OPTIMIZATION=-O3 -DNDEBUG -flto -march=native -mtune=native -funroll-loops)
+	$(eval override LDFLAGS += -flto)
 
 rebuild: clean $(TARGET)
 


### PR DESCRIPTION
## Summary
Add dedicated release build targets following the existing `debug`/`gperftools`/`callgrind` pattern.

Default `make` keeps asserts for development. CI benchmarks use `make release`.

## Targets

| Target | Flags | Portable | Use case |
|--------|-------|----------|----------|
| `make` (default) | `-O3` | Yes | Development — asserts on, catches bugs |
| `make release` | `-O3 -DNDEBUG -flto` | Yes | CI benchmarks, production builds |
| `make release-native` | `-O3 -DNDEBUG -flto -march=native -mtune=native -funroll-loops` | No (CPU-specific) | Local benchmarking, max perf |

## Changes
- `Makefile`: Add `release` and `release-native` targets with `release_prepare`/`release_native_prepare`
- `.github/workflows/run.yml`: CI benchmarks use `make release` instead of `make`

## Workflow
```bash
# Development (asserts on)
make && make test

# Release build (asserts off, LTO on)
make release
./cubotron --benchmark-slow

# Local max performance
make release-native
./cubotron --benchmark-slow
```

**Do not merge without explicit approval.**