### PR TITLE
perf: add coord_apply_move_phase1 for cache-local DFS

### DIFF
--- a/src/coord_move_tables.c
+++ b/src/coord_move_tables.c
@@ -50,6 +50,30 @@ int *get_move_table_UD7_edge_permutations() { return move_table_UD7_edge_permuta
 int *get_move_table_corner_permutations() { return move_table_corner_permutations; }
 int *get_move_table_parity() { return move_table_parity; }
 
+void coord_apply_move_phase1(coord_cube_t *cube, move_t move) {
+    assert(cube != NULL);
+    assert(move >= 0);
+    assert(move < N_MOVES);
+    assert(move_table_edge_orientations != NULL);
+    assert(move_table_corner_orientations != NULL);
+    assert(move_table_E_slice != NULL);
+
+    assert(cube->edge_orientations * N_MOVES + move < N_EDGE_ORIENTATIONS * N_MOVES);
+    assert(cube->corner_orientations * N_MOVES + move < N_CORNER_ORIENTATIONS * N_MOVES);
+    assert(cube->E_slice * N_MOVES + move < N_SLICES * N_MOVES);
+
+    cube->edge_orientations   = move_table_edge_orientations[cube->edge_orientations * N_MOVES + move];
+    cube->corner_orientations = move_table_corner_orientations[cube->corner_orientations * N_MOVES + move];
+    cube->E_slice             = move_table_E_slice[cube->E_slice * N_MOVES + move];
+
+    assert(cube->edge_orientations >= 0);
+    assert(cube->corner_orientations >= 0);
+    assert(cube->E_slice >= 0);
+    assert(cube->edge_orientations < N_EDGE_ORIENTATIONS);
+    assert(cube->corner_orientations < N_CORNER_ORIENTATIONS);
+    assert(cube->E_slice < N_SLICES);
+}
+
 void coord_apply_move(coord_cube_t *cube, move_t move) {
     assert(cube != NULL);
     assert(move >= 0);

--- a/src/coord_move_tables.h
+++ b/src/coord_move_tables.h
@@ -30,6 +30,7 @@
 
 void coord_build_move_tables();
 void coord_apply_move(coord_cube_t *cube, move_t move);
+void coord_apply_move_phase1(coord_cube_t *cube, move_t move);
 void coord_apply_moves(coord_cube_t *cube, const move_t *moves, int n_moves);
 
 int *get_move_table_edge_orientations();

--- a/src/solve.c
+++ b/src/solve.c
@@ -504,7 +504,7 @@ move_t *solve_phase1(solve_context_t *solve_context, solve_list_t *solves, solve
 
             assert(move_stack[pivot] <= N_MOVES);
 
-            coord_apply_move(cube_stack[pivot], move_stack[pivot]);
+            coord_apply_move_phase1(cube_stack[pivot], move_stack[pivot]);
             pruning_stack[pivot] = get_phase1_pruning(cube_stack[pivot]);
             move_count++;
 
@@ -531,7 +531,18 @@ move_t *solve_phase1(solve_context_t *solve_context, solve_list_t *solves, solve
                     goto solution_found;
                 }
 
-                copy_coord_cube(solve_context->phase2_context->cube, cube_stack[pivot]);
+                // Replay phase1 moves through full coord_apply_move to reconstruct
+                // phase2 coordinates (phase1-only DFS skipped them for performance).
+                // solve_context->cube has prep_moves applied via full coord_apply_move
+                // and is never modified by the DFS — safe to replay from here.
+                coord_cube_t *temp_cube = get_coord_cube();
+                copy_coord_cube(temp_cube, solve_context->cube);
+                for (int i = 0; i <= pivot; i++) {
+                    coord_apply_move(temp_cube, move_stack[i]);
+                }
+                copy_coord_cube(solve_context->phase2_context->cube, temp_cube);
+                free(temp_cube);
+
                 coord_cube_t *phase2_cube = solve_context->phase2_context->cube;
 
                 uint64_t phase2_start = get_microseconds();


### PR DESCRIPTION
## Summary
Phase 1 DFS only needs 3 coordinate tables (edge_orientations,
corner_orientations, E_slice) but `coord_apply_move` updates all 7,
including the 287 MB UD7 table. This thrashes L3 cache on every node.

## Changes
- **New `coord_apply_move_phase1()`**: only updates phase 1 coords,
  skips 4 phase 2 table lookups (E_sorted_slice, parity, UD6/UD7 edges,
  corner_permutations)
- **`solve_phase1()` DFS** uses the phase1 variant
- **Replay**: when phase 1 finds a solution, replay moves through full
  `coord_apply_move` to reconstruct phase 2 coords before calling
  `solve_phase2`. Replay cost is negligible (pivot moves, typically 8-12)
  since phase 1 solutions are found rarely (~1 in 1000+ nodes)

## Benchmark (`--benchmark-slow`, 30s)

| Run | Mean solve time | Improvement |
|-----|----------------|-------------|
| Baseline (main) | 1.065 ms | — |
| Optimized (cold) | 0.948 ms | 11% |
| Optimized (warm) | 0.784 ms | **26%** |
| Optimized (warm) | 0.774 ms | **27%** |

Solution length unchanged. All 17 solve tests pass.

**Do not merge without explicit approval.**