### PR TITLE
fix: resolve 5 critical bugs

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -118,6 +118,11 @@ int main(int argc, char **argv) {
                 }
 
                 config->max_depth = atoi(optarg);
+
+                if (config->max_depth > MAX_MOVES - 1) {
+                    fprintf(stderr, "Error: max_depth must be <= %d\n", MAX_MOVES - 1);
+                    return 1;
+                }
             } break;
 
             case 'n': {

--- a/src/solve.c
+++ b/src/solve.c
@@ -480,7 +480,7 @@ move_t *solve_phase1(solve_context_t *solve_context, solve_list_t *solves, solve
 
             do {
                 move_stack[pivot]++;
-            } while (config->move_black_list[move_stack[pivot]] != MOVE_NULL && move_stack[pivot] < N_MOVES);
+            } while (move_stack[pivot] < N_MOVES && config->move_black_list[move_stack[pivot]] != MOVE_NULL);
 
             if (move_stack[pivot] >= N_MOVES) {
                 pruning_stack[pivot] = -1; // ?

--- a/src/utils.c
+++ b/src/utils.c
@@ -279,10 +279,11 @@ void print_move_sequence(const move_t *moves) {
 }
 
 int are_move_sequences_equal(const move_t *moves1, const move_t *moves2) {
-    for (int i = 0; moves1[i] != MOVE_NULL && moves2[i] != MOVE_NULL; i++) {
+    int i = 0;
+    while (moves1[i] != MOVE_NULL && moves2[i] != MOVE_NULL) {
         if (moves1[i] != moves2[i])
             return 0;
+        i++;
     }
-
-    return 1;
+    return moves1[i] == MOVE_NULL && moves2[i] == MOVE_NULL;
 }

--- a/test/test_coord.c
+++ b/test/test_coord.c
@@ -64,7 +64,7 @@ void test_is_phase2_solved() {
     coord_apply_move(cube, MOVE_R3);
     coord_apply_move(cube, MOVE_F3);
 
-    TEST_ASSERT_TRUE(is_phase1_solved(cube));
+    TEST_ASSERT_TRUE(is_phase2_solved(cube));
 
     free(cube);
 }

--- a/test/test_coord_move_tables.c
+++ b/test/test_coord_move_tables.c
@@ -119,7 +119,6 @@ void test_coord_sanity_brute_force() {
 }
 
 void test_coord_orientation_changes() {
-    TEST_PASS();
     coord_cube_t *coord_cube = get_coord_cube();
 
     coord_apply_move(coord_cube, MOVE_R1);

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -153,13 +153,10 @@ void test_are_move_sequences_equal() {
     move_t *moves2 = move_sequence_str_to_moves("U R2 F D' L B");
     move_t *moves3 = move_sequence_str_to_moves("D R2 F D' L B'");
 
-    // Same sequence
     TEST_ASSERT_TRUE(are_move_sequences_equal(moves1, moves2));
-    // Different same-length sequences
     TEST_ASSERT_FALSE(are_move_sequences_equal(moves1, moves3));
     TEST_ASSERT_FALSE(are_move_sequences_equal(moves2, moves3));
 
-    // Different-length sequences — should NOT be equal
     move_t *short_moves = move_sequence_str_to_moves("U R2");
     TEST_ASSERT_FALSE(are_move_sequences_equal(moves1, short_moves));
     TEST_ASSERT_FALSE(are_move_sequences_equal(short_moves, moves1));

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -153,9 +153,17 @@ void test_are_move_sequences_equal() {
     move_t *moves2 = move_sequence_str_to_moves("U R2 F D' L B");
     move_t *moves3 = move_sequence_str_to_moves("D R2 F D' L B'");
 
+    // Same sequence
     TEST_ASSERT_TRUE(are_move_sequences_equal(moves1, moves2));
+    // Different same-length sequences
     TEST_ASSERT_FALSE(are_move_sequences_equal(moves1, moves3));
     TEST_ASSERT_FALSE(are_move_sequences_equal(moves2, moves3));
+
+    // Different-length sequences — should NOT be equal
+    move_t *short_moves = move_sequence_str_to_moves("U R2");
+    TEST_ASSERT_FALSE(are_move_sequences_equal(moves1, short_moves));
+    TEST_ASSERT_FALSE(are_move_sequences_equal(short_moves, moves1));
+    free(short_moves);
 
     free(moves1);
     free(moves2);


### PR DESCRIPTION
## Summary
Five critical bugs from the code audit, all one-line fixes.

## Changes

| ID | Bug | File:Line | Fix |
|----|-----|-----------|-----|
| B1 | OOB read in solve_phase1 blacklist loop | solve.c:503 | Swap `&&` operands — bounds check first |
| B2 | Stack/heap overflow with `--max-depth > 30` | main.c:120 | Validate `max_depth <= MAX_MOVES - 1` |
| B3 | `are_move_sequences_equal` false positive for different-length sequences | utils.c:287 | Check both terminators |
| B4 | `test_is_phase2_solved` tests wrong function | test_coord.c:67 | `is_phase1_solved` → `is_phase2_solved` |
| B5 | `test_coord_orientation_changes` is a no-op | test_coord_move_tables.c:122 | Remove `TEST_PASS()` |

## Tests
- All existing tests pass
- Added different-length sequence test for `are_move_sequences_equal`
- `./cubotron --max-depth 31 --solve-scramble "U R"` exits with error (no crash)

**Do not merge without explicit approval.**