### PR TITLE
fix(benchmark): capture warmup end time before benchmark phase

### DIFF
--- a/src/benchmark.c
+++ b/src/benchmark.c
@@ -109,6 +109,8 @@ static void run_benchmark_internal(const char *base_type, int warmup_duration_ms
 
     printf("  Completed %d warmup solves\n\n", warmup_count);
 
+    uint64_t warmup_end = get_microseconds();
+
     printf("Benchmark phase...\n");
     int     max_samples  = 1000000;
     double *temp_times   = malloc(max_samples * sizeof(double));
@@ -153,7 +155,7 @@ static void run_benchmark_internal(const char *base_type, int warmup_duration_ms
     benchmark_result_t *result = make_benchmark_result(sample_count);
     snprintf(result->type, sizeof(result->type), "%s", type);
     result->warmup_count          = warmup_count;
-    result->warmup_duration_ms    = (int)(get_microseconds() - warmup_start) / 1000;
+    result->warmup_duration_ms    = (int)(warmup_end - warmup_start) / 1000;
     result->benchmark_duration_ms = (int)actual_bench_duration / 1000;
     result->solves_per_second     = sample_count / (actual_bench_duration / 1000000.0);
 


### PR DESCRIPTION
## Bug
Warmup duration in benchmark results was incorrect. It showed ~5500 ms for `--benchmark-fast` (500ms warmup + 5000ms benchmark + processing). The reported warmup time included the entire benchmark phase.

## Root cause
`warmup_duration_ms` was calculated as:
```c
result->warmup_duration_ms = (int)(get_microseconds() - warmup_start) / 1000;
```
But `get_microseconds()` was called at line 156, **after** the benchmark phase completed. So it captured warmup + benchmark + result processing time.

## Fix
Capture `warmup_end = get_microseconds()` immediately after the warmup loop ends (line 110), before the benchmark phase starts. Use `warmup_end - warmup_start` for the warmup duration report.

## Before/After
| | Warmup reported | Actual warmup |
|---|---|---|
| Before | ~5501 ms | 500 ms |
| After | 500 ms | 500 ms |

**Do not merge without explicit approval.**