### PR TITLE
fix: account for prep_moves in max_depth budget

### DIFF
--- a/src/solve.c
+++ b/src/solve.c
@@ -465,7 +465,7 @@ move_t *solve_phase1(solve_context_t *solve_context, solve_list_t *solves, solve
 
     solve_list_t *solves_head = solves;
 
-    for (int allowed_depth = 1; allowed_depth <= config->max_depth; allowed_depth++) {
+    for (int allowed_depth = 1; allowed_depth <= config->max_depth - solve_context->prep_move_count; allowed_depth++) {
         int pivot = 0;
         /*printf("searching with max depth: %d\n", allowed_depth);*/
 
@@ -547,7 +547,8 @@ move_t *solve_phase1(solve_context_t *solve_context, solve_list_t *solves, solve
 
                 uint64_t phase2_start = get_microseconds();
                 move_t  *phase2_solution =
-                    solve_phase2(solve_context->phase2_context, config, config->max_depth - pivot - 1, stats);
+                    solve_phase2(solve_context->phase2_context, config,
+                                 config->max_depth - solve_context->prep_move_count - pivot - 1, stats);
                 uint64_t phase2_end = get_microseconds();
                 phase2_time += phase2_end - phase2_start;
                 stats->phase2_attempts++;


### PR DESCRIPTION
## Bug
`--max-depth=21` allowed solutions up to 22 moves. The depth budget didn't account for prep_moves (each thread prepends 1 move).

## Fix
Subtract `solve_context->prep_move_count` from the depth budget in two places:
1. Outer search loop: `config->max_depth - prep_move_count`
2. Phase2 allocation: `config->max_depth - prep_move_count - pivot - 1`

## Verification
`./cubotron --benchmark-fast --max-depth=21` now shows `Max: 21 moves` (was 22).

**Do not merge without explicit approval.**