### PR TITLE
build: add -Wshadow to CFLAGS and fix shadowing bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ifeq ($(UNAME_S),Darwin)
   LDFLAGS = -lpcg_random -lm -Wl,-Ldeps/pcg-c/src/
 endif
 
-override CFLAGS += -Wall -Wextra -pedantic -Werror -std=gnu11 $(OPTIMIZATION) $(OPTIONS) $(INCLUDES)
+override CFLAGS += -Wall -Wextra -Wshadow -pedantic -Werror -std=gnu11 $(OPTIMIZATION) $(OPTIONS) $(INCLUDES)
 
 CC = gcc
 

--- a/test/test_coord_move_tables.c
+++ b/test/test_coord_move_tables.c
@@ -134,7 +134,7 @@ void test_moves_are_reversible() {
     const int n_moves = 50;
     move_t    moves[52];
 
-    for (int i = 0; i < 1000; i++) {
+    for (int iter = 0; iter < 1000; iter++) {
         coord_cube_t *cube      = random_coord_cube();
         coord_cube_t *reference = get_coord_cube();
         copy_coord_cube(reference, cube);

--- a/test/test_solve.c
+++ b/test/test_solve.c
@@ -35,8 +35,8 @@ void test_random_phase1_solving() {
 
         move_t *solution = solutions->solution;
 
-        for (int i = 0; solution[i] != MOVE_NULL; i++) {
-            coord_apply_move(cube, solution[i]);
+        for (int j = 0; solution[j] != MOVE_NULL; j++) {
+            coord_apply_move(cube, solution[j]);
         }
 
         TEST_ASSERT_TRUE(is_phase1_solved(cube));
@@ -171,8 +171,8 @@ void test_random_full_solver_with_random_scrambles_single_solution() {
 
         solve_list_t *solution = solve_single(cube);
 
-        for (int i = 0; solution->solution[i] != MOVE_NULL; i++) {
-            coord_apply_move(cube, solution->solution[i]);
+        for (int j = 0; solution->solution[j] != MOVE_NULL; j++) {
+            coord_apply_move(cube, solution->solution[j]);
         }
 
         TEST_ASSERT_TRUE(is_phase1_solved(cube));
@@ -254,8 +254,8 @@ void test_random_full_solver_with_sample_cubes_single_solution() {
 
         solve_list_t *solution = solve_single(cube);
 
-        for (int i = 0; solution->solution[i] != MOVE_NULL; i++) {
-            coord_apply_move(cube, solution->solution[i]);
+        for (int j = 0; solution->solution[j] != MOVE_NULL; j++) {
+            coord_apply_move(cube, solution->solution[j]);
         }
 
         TEST_ASSERT_TRUE(is_phase1_solved(cube));
@@ -297,15 +297,15 @@ void test_solve_with_move_blacklist() {
 
             solve_list_t *solution = solve(cube, config);
 
-            for (int i = 0; solution->solution[i] != MOVE_NULL; i++) {
-                coord_apply_move(cube, solution->solution[i]);
+            for (int j = 0; solution->solution[j] != MOVE_NULL; j++) {
+                coord_apply_move(cube, solution->solution[j]);
 
-                if (move_to_str(solution->solution[i])[0] == blacklisted_char) {
+                if (move_to_str(solution->solution[j])[0] == blacklisted_char) {
                     sprintf(buffer, "solution has blacklisted move:");
 
-                    for (int i = 0; solution->solution[i] != MOVE_NULL; i++) {
+                    for (int k = 0; solution->solution[k] != MOVE_NULL; k++) {
                         strncat(buffer, " ", sizeof(buffer) - strlen(buffer) - 1);
-                        strncat(buffer, move_to_str(solution->solution[i]), sizeof(buffer) - strlen(buffer) - 1);
+                        strncat(buffer, move_to_str(solution->solution[k]), sizeof(buffer) - strlen(buffer) - 1);
                     }
 
                     TEST_MESSAGE(buffer);


### PR DESCRIPTION
Variable shadowing is a common source of logic bugs. Without `-Wshadow`, the compiler won't warn when a local variable hides an outer-scope variable.

Changes:
- Added `-Wshadow` to CFLAGS in the Makefile
- Fixed 5 shadowing bugs exposed by the flag: `test/test_solve.c` (4 instances of inner `i` → `j`) and `test/test_coord_move_tables.c` (inner `i` → `iter`)

The project builds and all tests pass with this flag enabled.